### PR TITLE
GitHub Actions 스크립트 추가 설정

### DIFF
--- a/.github/workflows/full-deploy.yml
+++ b/.github/workflows/full-deploy.yml
@@ -44,5 +44,5 @@ jobs:
           port: 22
           script: |
             cd /home/flip
-            sudo docker compose pull
-            sudo docker compose up -d
+            sudo docker compose pull flip
+            sudo docker compose up -d flip

--- a/.github/workflows/full-deploy.yml
+++ b/.github/workflows/full-deploy.yml
@@ -45,4 +45,4 @@ jobs:
           script: |
             cd /home/flip
             sudo docker compose pull flip
-            sudo docker compose up -d flip
+            sudo docker compose up -d flip --no-deps


### PR DESCRIPTION
GCP 서버에서 docker-compose.yml 설정이 다음과 같이 되어 있다.

```
services:
  redis:
    image: redis:7
    container_name: redis
```

때문에 --no-deps 설정을 추가하여 다음과 같이 되도록 한다.

1. depends_on: redis는 무시
2. 이미 실행 중인 Redis는 그대로 유지
3. flip 서비스만 업데이트