### PR TITLE
🐛fix: script 수정

### DIFF
--- a/.github/workflows/full-deploy.yml
+++ b/.github/workflows/full-deploy.yml
@@ -44,5 +44,6 @@ jobs:
           port: 22
           script: |
             cd /home/flip
+            sudo docker compose down flip || true
             sudo docker compose pull flip
             sudo docker compose up -d flip --no-deps


### PR DESCRIPTION
Flip 컨테이너 자체가 중복된 이름으로 인해 충돌 문제 개선

```
sudo docker compose down flip || true
```

위 명령어를 추가하여, 기존 컨테이너를 제거 후 새로 시작