### PR TITLE
🐛 fix: ScheduleResponse Tag 우선 적용 및 SecurityFilterChain 조건 수정 (#28)

### DIFF
--- a/src/main/java/com/DoIt2/Flip/domain/schedule/dto/ScheduleResponse.java
+++ b/src/main/java/com/DoIt2/Flip/domain/schedule/dto/ScheduleResponse.java
@@ -40,8 +40,12 @@ public class ScheduleResponse {
                 .title(schedule.getTitle())
                 .location(schedule.getLocation())
                 .participants(schedule.getParticipants())
-                .color(schedule.getColor())
-                .iconId(schedule.getIcon() != null ? schedule.getIcon().getIconId() : null)
+                .color(schedule.isExistTag() && schedule.getTag() != null
+                        ? schedule.getTag().getColor()
+                        : schedule.getColor())
+                .iconId(schedule.isExistTag() && schedule.getTag() != null
+                        ? (schedule.getTag().getIcon() != null ? schedule.getTag().getIcon().getIconId() : null)
+                        : (schedule.getIcon() != null ? schedule.getIcon().getIconId() : null))
                 .tagId(schedule.getTag() != null ? schedule.getTag().getTagId() : null)
                 .isRepeat(schedule.isRepeat())
                 .isExistTag(schedule.isExistTag())

--- a/src/main/java/com/DoIt2/Flip/global/config/SecurityConfig.java
+++ b/src/main/java/com/DoIt2/Flip/global/config/SecurityConfig.java
@@ -63,7 +63,7 @@ public class SecurityConfig {
                 CorsConfiguration configuration = new CorsConfiguration();
 
                 configuration.setAllowedOrigins(Collections.singletonList("http://localhost:3000")); // 허용할 주소
-                configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS")); // 허용할 HTTP methods
+                configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE","PATCH", "OPTIONS")); // 허용할 HTTP methods
                 configuration.setAllowedHeaders(List.of("Authorization", "Content-Type", "X-Requested-With")); // 허용할 Header
                 configuration.setAllowCredentials(true);
                 configuration.setMaxAge(3600L); // 허용 시간


### PR DESCRIPTION
1. ScheduleResponse Tag 우선 적용

- 일정(Schedule)에 태그(Tag)가 존재하는 경우(`isExistTag == true`), 기존에는 색상(color)과 아이콘(iconId)이 스케줄 자체의 값으로 응답되던 버그가 있었습니다.
- 이를 수정하여, `isExistTag == true`이고 `Tag`가 존재하는 경우에는 `Tag`의 color와 icon 정보를 우선적으로 사용하도록 반영했습니다.

2. SecurityFilterChain 조건 수정

- Security 설정에서 허용 경로 및 OPTIONS preflight 요청 처리를 명시적으로 정의하였습니다.
- 불필요하거나 중복되는 필터 조건을 정리하고, `authorizeHttpRequests`에 OPTIONS 요청 조건을 추가하여 CORS 관련 동작을 안정화했습니다.